### PR TITLE
docs: restructure README into a front door + topical reference docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -326,8 +326,9 @@ The Redis backend accepts a user-provided `redis.asyncio.Redis` (or `redis.Redis
 
 If you need to bound connection usage, use `BlockingConnectionPool` before passing the client to the rate limiter. Size `max_connections` to at least your expected `max_concurrent_acquires` plus headroom for Redis lock acquire/release, the `TIME` command, and pipeline reads/writes. As a starting point, use `max_connections >= max_concurrent_acquires + 10` and tune from Redis pool wait time and server connection metrics. The Redis backend emits a `RuntimeWarning` when it sees `max_connections < 10`, because that is usually too small for production traffic.
 
-The README sizing numbers come from R7 short local runs and Redis object-size
-estimates, not a maintained sustained-load production benchmark suite. Treat
+The sizing numbers in [docs/operations.md](docs/operations.md#performance-and-capacity-planning)
+come from short local runs and Redis object-size estimates, not a maintained
+sustained-load production benchmark suite. Treat
 them as planning guidance only and validate throughput, p99 latency, key
 cardinality, memory, and `maxclients` pressure under the workload and Redis
 configuration you will run in production.

--- a/README.md
+++ b/README.md
@@ -14,15 +14,13 @@
 
 Works with any LLM provider and any client library — token-throttle limits the _rate_, not the _client_.
 
-> **Breaking releases:** [v2](MIGRATION.md#migrating-from-v14x-to-v200), [v5](MIGRATION.md#migrating-from-v4x-to-v500), [v6](MIGRATION.md#migrating-from-v5x-to-v600), [v7](MIGRATION.md#migrating-from-v6x-to-v700), and [v8](MIGRATION.md#migrating-from-v7x-to-v800) each changed upgrade-sensitive contracts.
-
-Public constants and type aliases are documented in [docs/api.md](docs/api.md).
-
 ```bash
 pip install "token-throttle[redis,tiktoken]>=8.0.6,<8.1.0"   # OpenAI + Redis (recommended)
 pip install "token-throttle[redis]>=8.0.6,<8.1.0"            # Any provider + Redis
 pip install "token-throttle>=8.0.6,<8.1.0"                   # Any provider + in-memory
 ```
+
+Upgrading from an earlier major version? See [MIGRATION.md](MIGRATION.md) for the v2/v5/v6/v7/v8 contract changes. Public constants and type aliases: [docs/api.md](docs/api.md).
 
 ## Quickstart
 
@@ -88,11 +86,11 @@ asyncio.run(main())
 Install token-throttle's Redis and tokenizer extras plus the OpenAI client:
 
 ```bash
-pip install "token-throttle[redis,tiktoken]" openai
+pip install "token-throttle[redis,tiktoken]>=8.0.6,<8.1.0" openai
 ```
 
 ```python
-# (fragment — see Memory quickstart for standalone context)
+# (fragment — needs a live Redis + OPENAI_API_KEY; see the Memory quickstart to run end-to-end)
 import asyncio
 
 import redis.asyncio as redis
@@ -136,17 +134,12 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-`OpenAIUsageCounter` supports text-only OpenAI payloads that use the real API
-fields `input` or `messages`. The plural `inputs` field is not an OpenAI request
-field and is rejected. Image, audio, and file inputs are unsupported; pass usage
-manually for those.
-
-Token estimates are bounded by `tiktoken`'s model encodings plus local
-best-effort heuristics for chat/message overhead, tools, functions, schemas,
-and output budgets. They have not been reconciled against live OpenAI billing
-dashboards across a request corpus; periodically compare reserved tokens with
-your actual billing and pass usage manually where local counting is not
-representative.
+`OpenAIUsageCounter` counts text-only OpenAI payloads (`input` or `messages`,
+plus chat/tool/schema/output overhead via `tiktoken`). The plural `inputs` field
+and image/audio/file inputs are unsupported — pass usage manually for those.
+Estimates are best-effort and not reconciled against live billing, so compare
+reserved tokens with actual usage periodically. Full contract:
+[docs/configuration.md](docs/configuration.md#usage-counters).
 
 ### Any provider (manual usage)
 
@@ -216,22 +209,12 @@ The Redis backend uses sorted locking to prevent deadlocks when acquiring multip
 
 ### Reservation lifecycle
 
-A `CapacityReservation` is an internal accounting token, not a durable portable
-credential. Refund it on the same limiter lifetime that issued it, after the API
-call finishes. If your config changes before refund, token-throttle refunds only
-the surviving buckets that still correspond to the reservation; buckets removed
-by a callable-config rebuild are skipped to avoid crediting unrelated capacity.
-
-Unlimited reservations are no-ops on refund. They are trusted in-process
-objects, so do not deserialize, pickle, or accept reservations across trust
-boundaries as proof that a caller was rate-limited. For queue-and-retry
-workflows, reserve immediately before dispatching the external request rather
-than storing reservations in a long-lived queue.
-
-v2.0.0 is a clean break from v1.4.x reservation compatibility. Every
-`CapacityReservation` requires a non-empty `limiter_instance_id`; legacy
-v1.4.x reservations without it are rejected. Drain in-flight reservations
-before upgrading and do not run mixed v1.4.x/v2.0.0 fleets.
+Reserve before the call, refund after — on the **same limiter** that issued the
+reservation, immediately around the external request (not from a long-lived
+queue). A `CapacityReservation` is a trusted in-process accounting token, not a
+portable credential: don't pickle it or pass it across trust boundaries.
+Durability semantics, config-change behavior, and the v2.0.0 compatibility break
+are covered in [docs/operations.md](docs/operations.md#reservation-lifecycle-and-durability).
 
 ## Configuration
 
@@ -273,52 +256,10 @@ limiter = RateLimiter(
 
 Models that share a `model_family` must also share the same live quota definition. If two model names need different limits, give them different `model_family` values instead of reusing one family name.
 
-`model_family` defaults to the request model name. A typo such as
-`"gpt-4o-mini-prod"` therefore creates a distinct family. Limiters fail closed
-once mandatory in-process caps are reached: by default 10,000 model families,
-100 metrics per family, 10,000 model aliases, and 100,000 in-flight
-reservations. Key-segment length is also capped by default: model families and
-aliases at 256 characters, metrics at 64 characters. Tune these constructor
-arguments lower for tighter deployments and validate model names in your
-application if they come from users or configuration.
-
-Long-lived dynamic deployments should periodically call
-`limiter.clear_unused_model_families(unused_for_seconds)` (or the sync method
-with the same name) from an operator-controlled maintenance path. It evicts idle
-in-process family caches and skips families with in-flight reservations. Redis
-bucket keys expire separately through the Redis bucket TTL.
-
-To disable rate limiting for a model while keeping the same API surface, return
-an unlimited config:
-
-```python
-# (fragment — see Per-model configuration for context)
-PerModelConfig(
-    quotas=UsageQuotas.unlimited(),
-    model_family="paid-tier",
-)
-```
-
-Unlimited configs still validate direct usage values for `acquire_capacity()`
-but do not require usage keys to match quota names because there are no quotas.
-For `acquire_capacity_for_request()`, a configured `usage_counter` may still run
-for telemetry; any `extra_usage` keys are accepted and then discarded with the
-unlimited reservation. If you toggle a model between limited and unlimited,
-keep `extra_usage` keys compatible with the limited quota metrics.
-
-`OpenAIUsageCounter` handles text-only OpenAI requests. It counts `input` or
-`messages`, plus prompt-bearing request context such as `instructions`,
-tool/function definitions, and structured output schemas. The plural `inputs`
-field is rejected because it is not an OpenAI request field. Image/audio/file
-inputs are still unsupported; pass usage manually for those.
-
-Custom `usage_counter` callables receive the same kwargs you pass to
-`acquire_capacity_for_request()`. They can accept `**request` for the whole
-payload or only the named request fields they use; fixed-signature counters do
-not need to accept unrelated kwargs like `model`. Custom counters are trusted
-application code: nested request objects are passed by reference, so counters
-should avoid mutating them. Return a plain `dict` or another well-behaved
-mapping of metric names to finite numeric values.
+Limiters fail closed at sensible in-process caps (model families, metrics,
+aliases, in-flight reservations) and support unlimited configs, custom
+`usage_counter` callables, and idle-family eviction for long-lived deployments.
+See [docs/configuration.md](docs/configuration.md#per-model-configuration).
 
 ### Backends
 
@@ -342,154 +283,17 @@ quota state. Use different prefixes for unrelated deployments sharing one Redis
 deployment. The prefix and user-controlled key segments cannot contain
 `:`, `{`, `}`, whitespace, or control characters.
 
-#### Redis topology support
+### Running in production (Redis)
 
-token-throttle supports standalone Redis and Sentinel-managed Redis primary
-deployments. It does not support Redis Cluster or client-side sharded Redis.
-The Redis backend uses multi-key Lua scripts for atomic acquire-marker and
-refund updates; in Redis Cluster those keys can span hash slots and fail at
-runtime. `RateLimiter` and `SyncRateLimiter` reject redis-py `RedisCluster`
-clients during construction with a `ValueError` instead of failing later during
-`EVAL`.
+Distributed deployments have operational considerations worth reading before you
+ship: supported Redis topologies (standalone and Sentinel — **not** Redis
+Cluster or client-side sharding), multi-tenant isolation limits, connection-pool
+sizing, key TTLs, and capacity planning for high-RPS fleets. See
+[docs/operations.md](docs/operations.md).
 
-Do not add caller-controlled Redis hash tags to key prefixes, model families,
-metrics, reservation ids, or other key segments. Public validators reject `{`
-and `}` in Redis key segments, and Cluster support is intentionally unsupported.
-
-Redis backends require Redis server 6.2 or newer and a Redis user that can run
-`GET`, `EXISTS`, `SET`, `DEL`, `EXPIRE`, `TIME`, and Lua scripting commands
-used by redis-py locks and token-throttle acquire/refund transactions.
-
-R7 validation used `fakeredis` plus local vanilla Redis 7.x. Redis 6.0/6.1 are
-outside the supported version range, and the R7 matrix did not validate
-Sentinel failover behavior, KeyDB, Dragonfly, client-side sharding, or low
-`maxmemory` / low `maxclients` configurations. KeyDB and Dragonfly may work as
-Redis-compatible servers, but they are untested and not officially supported;
-validate topology and resource limits in your environment.
-
-#### Multi-tenant deployments
-
-`key_prefix` provides namespace isolation only. It keeps one tenant's Redis
-keys from colliding with another tenant's keys, but it is not resource
-isolation. Tenants that share a Redis server still share Redis CPU, memory,
-`maxclients`, command scheduling, Lua script execution time, network bandwidth,
-and eviction policy.
-
-Do not rely on `key_prefix` for hostile-tenant fairness. A hostile or runaway
-tenant on shared Redis can starve benign tenants by exhausting connections,
-memory, CPU, or Lua scheduling. For hostile-tenant scenarios, use separate
-Redis instances per tenant, or place Redis behind infrastructure that enforces
-hardware-level CPU, memory, connection, and network quotas per tenant.
-See `MIGRATION.md` for the v4 multi-tenant isolation decision.
-
-For bounded Redis deployments, prefer `redis.asyncio.BlockingConnectionPool`
-or `redis.BlockingConnectionPool` and size `max_connections` to at least
-`max_concurrent_acquires` plus headroom for Redis lock acquire/release, `TIME`,
-and pipeline commands. A pool below 10 connections triggers a runtime warning
-because it is usually too small for production traffic.
-
-Redis bucket state expires by default after 7 days of inactivity. Configure
-`bucket_ttl_seconds` on Redis builders or Redis OpenAI factories to choose a
-different positive TTL. The TTL is refreshed whenever bucket state is read or
-written; Redis schema-version registry keys are intentionally long-lived and do
-not expire.
-
-Redis refunds also write a cross-process idempotency key:
-`{key_prefix}:rate_limiting:refund_dedup:{reservation_id}`. The TTL defaults to
-7 days and can be changed with `refund_dedup_ttl_seconds` on Redis backend
-builders or Redis OpenAI factories. Memory backends keep only process-local
-refund dedup state and cannot safely refund reservations after a cold restart.
-
-#### Performance and capacity planning
-
-R7 performance testing identified two important ceilings for 10k RPS-class
-deployments:
-
-- A single hot Redis bucket can become the throughput ceiling before 10k RPS
-  because all callers contend on the same Redis lock and Lua-scripted state.
-- The async memory backend is process-local and can also hit an in-process
-  scheduling/lock ceiling before 10k RPS; it is not a horizontal scaling
-  substitute for Redis.
-
-Exact throughput and p99 latency depend on Redis CPU, network RTT, Python
-runtime, concurrency, quota shape, and how concentrated traffic is on one
-model family. Treat 10k RPS as a workload that requires staging benchmarks with
-your real quota mix. These numbers are based on short local runs and sizing
-estimates, not sustained-load production validation; a maintained production
-benchmark suite is deferred. As a starting planning table:
-
-| Sustained acquire/refund rate | Expected p99 driver | Operational guidance |
-| ---: | --- | --- |
-| 100 RPS | Redis RTT plus Python scheduling | Default Redis client pools usually work; still set timeouts and monitor waits. |
-| 1k RPS | Lock contention, Redis CPU, pool wait | Use `BlockingConnectionPool`, provision Redis CPU headroom, and benchmark p99 under peak concurrency. |
-| 10k RPS | Hot buckets, Lua scheduling, key churn | Avoid concentrating all traffic in one model family/window; use dedicated Redis capacity and load-test before production. |
-
-Redis backends create short-lived per-reservation keys in addition to bucket
-state. Size Redis from traffic rate and TTLs, not only from the number of model
-families:
-
-- Acquire marker keys, rough count:
-  `acquires_per_second * max_reservation_lifetime_seconds`.
-- Refund dedup keys, rough count:
-  `refunds_per_second * refund_dedup_ttl_seconds`.
-
-The Redis default TTLs are intentionally conservative for correctness and
-compatibility: `bucket_ttl_seconds=604800` and
-`refund_dedup_ttl_seconds=604800` (7 days). With no explicit
-`max_reservation_lifetime_seconds`, Redis derives the reservation lifetime from
-the shorter Redis TTL: just below
-`min(bucket_ttl_seconds, refund_dedup_ttl_seconds) / 2`. At 10k acquires/sec,
-the default derived marker lifetime is about 302,400 seconds, which can imply
-roughly 3.0 billion marker keys. Tune these values for sustained high-RPS
-deployments.
-
-A practical starting point is to choose the smallest reservation lifetime that
-covers normal request latency, retry delay, and shutdown drain time, then choose
-`bucket_ttl_seconds` and `refund_dedup_ttl_seconds` longer than twice that
-lifetime. Redis enforces this invariant:
-`bucket_ttl_seconds > max_reservation_lifetime_seconds * 2` and
-`refund_dedup_ttl_seconds > max_reservation_lifetime_seconds * 2`. The margin
-keeps bucket state, acquire markers, and refund tombstones alive for the full
-window in which a reservation can still be refunded.
-
-Example budgets for a tuned deployment, assuming about 0.5-1.0 KB per marker or
-dedup key after Redis object overhead and leaving operational headroom:
-
-| Traffic | Example knobs | Approx keys | Suggested Redis memory budget |
-| --- | --- | ---: | ---: |
-| 1k acquire/refund RPS | `max_reservation_lifetime_seconds=300`, `refund_dedup_ttl_seconds=600`, `bucket_ttl_seconds=900` | 300k markers + 600k dedup keys | 1-2 GB |
-| 10k acquire/refund RPS | `max_reservation_lifetime_seconds=300`, `refund_dedup_ttl_seconds=600`, `bucket_ttl_seconds=900` | 3M markers + 6M dedup keys | 10-20 GB |
-
-Validate with `INFO memory`, `DBSIZE` or keyspace scans in staging because Redis
-memory per key depends on key-prefix length, allocator behavior, and value size.
-
-Sample Redis monitoring points:
-
-```text
-INFO commandstats   # eval/evalsha, set, get, del latency and call volume
-INFO clients        # connected_clients, blocked_clients, maxclients pressure
-INFO memory         # used_memory, mem_fragmentation_ratio, evicted_keys
-INFO stats          # instantaneous_ops_per_sec, rejected_connections
-LATENCY LATEST      # server-side latency spikes
-SLOWLOG GET 128     # slow Lua scripts or lock commands
-```
-
-Application-side monitoring should track acquire wait duration, timeout count,
-callback errors, `snapshot_state()["in_flight_reservations"]`, Redis pool wait
-time, and p50/p95/p99 latency for acquire and refund calls.
-
-Custom backends implement `RateLimiterBackend` or `SyncRateLimiterBackend`.
-Required operations are capacity wait/consume/refund and `set_max_capacity`.
-Optional extension points include `refund_capacity_for_buckets`,
-`apply_configured_max_capacity`, `supports_metric_set_change`, and
-`prepare_reconfigured_backend`. See [`docs/custom-backends.md`](docs/custom-backends.md)
-for the protocol contract and conformance helper.
-
-Leave `supports_metric_set_change()` as `False` unless bucket additions/removals
-can preserve live state for surviving metrics. To return `True`, either keep
-bucket state in stable external storage keyed by metric/window, or override
-`prepare_reconfigured_backend()` to migrate in-process state into the rebuilt
-backend. Returning `True` with a no-op migration can silently reset accounting.
+Custom backends implement `RateLimiterBackend` or `SyncRateLimiterBackend`. See
+[docs/custom-backends.md](docs/custom-backends.md) for the protocol contract and
+conformance helper.
 
 ### Dynamic rate limits
 
@@ -498,7 +302,7 @@ adaptive rate limiting (e.g., reacting to `x-ratelimit-*` response headers):
 
 ```python
 # (fragment — see Any provider example for standalone context)
-# After at least one acquire/record call for this model:
+# After the limiter has initialized this model with an acquire call:
 await limiter.set_max_capacity(
     model="gpt-4o",
     metric="tokens",
@@ -508,21 +312,11 @@ await limiter.set_max_capacity(
 ```
 
 For Redis backends the new limit is written to Redis, so all processes
-sharing the same Redis see the change within ~1 second. This persisted Redis
-value is an explicit runtime override; static quota changes from your config do
-not rewrite it automatically.
+sharing the same Redis see the change within ~1 second.
 
-If a callable config removes a bucket and later re-adds it, the re-added
-bucket starts from the static quota in the current config. Runtime overrides
-from earlier `set_max_capacity()` calls do not survive a remove-and-readd;
-call `set_max_capacity()` again if you want the override restored.
-
-If you want to change the static configured quota, update the callable config
-and let the limiter rebuild on the next acquire/refund. `set_max_capacity()` is
-an explicit runtime override, not a config edit. Config rotations concurrent
-with `set_max_capacity()` are ordered by whichever backend update completes
-last; a later config rebuild resolves back to the static quota unless you
-reapply the override.
+Runtime-override semantics — Redis propagation, remove-and-readd behavior, and
+ordering against concurrent config rotations — are covered in
+[docs/configuration.md](docs/configuration.md#dynamic-rate-limits).
 
 ### Timeout
 
@@ -553,33 +347,14 @@ reservation = await limiter.acquire_capacity(
 `timeout` is not a total wall-clock deadline: backend operation latency
 (including Redis round trips) is outside this budget.
 
-User callbacks are bounded separately by `callback_timeout` on `RateLimiter`
-and `SyncRateLimiter` (default: 30 seconds per callback). When a callback
-exceeds that limit, token-throttle logs a warning, skips the callback result,
-and does not fail the acquire/refund call. Pass `callback_timeout=None` to
-restore unbounded callback execution. Timeout-wrapped sync callbacks run in a
-helper thread with the caller's `contextvars` context copied into that thread.
+User callbacks are bounded separately by `callback_timeout` (default 30s); see
+[docs/observability.md](docs/observability.md#callback-timeouts).
 
 ## Observability
 
 token-throttle stays framework-agnostic: it exposes logging, callbacks, and a
 small health snapshot, but does not depend on Prometheus, OpenTelemetry, or any
 metrics SDK. Wire these surfaces to your own collectors.
-
-Every `RateLimiter` and `SyncRateLimiter` logs the `token_throttle` package
-version at `INFO` during initialization. Existing callback loggers use the
-`token_throttle` logger by default through `create_logging_callbacks()` and
-`create_sync_logging_callbacks()`. Redis internals also emit structured
-`DEBUG` records under:
-
-- `token_throttle.acquire` for acquire marker reads/writes/deletes.
-- `token_throttle.refund` for refund marker GET/DEL and refund-dedup writes.
-- `token_throttle.lock` for Redis lock acquire, release, and extension events.
-
-Redis debug records include a `token_throttle_event` logging attribute with
-`event_type`, `reservation_id`, `bucket_id`, and operation-specific fields. For
-example, a stdlib handler can read `record.token_throttle_event` and turn it
-into counters or spans.
 
 Use `snapshot_state()` for a redacted point-in-time health check:
 
@@ -594,10 +369,6 @@ state = limiter.snapshot_state()
 #     "refund_dedup_count_estimate": 120,
 # }
 ```
-
-For Redis backends, marker and refund-dedup counts are best-effort local
-estimates from limiter bookkeeping, not a cross-process Redis inventory. The
-snapshot intentionally omits Redis URLs, credentials, and Redis key prefixes.
 
 For request correlation without changing existing callback signatures, use the
 additive lifecycle callback:
@@ -622,28 +393,9 @@ limiter = RateLimiter(
 )
 ```
 
-Lifecycle events include `event_type`, `reservation_id`, optional `request_id`
-from `acquire_capacity_for_request(..., request_id="...")`, `model_family`,
-`model_alias`, `bucket_ids`, `usage`, and `timestamp`. Existing wait, consume,
-refund, and missing-data callbacks keep their original keyword signatures.
-Public token-throttle exception classes expose a stable `reason` attribute
-where callers need structured error handling.
-
-PII surface:
-
-- User-controlled fields: request `model`, lifecycle `model_alias`, optional
-  `request_id`, custom usage metric names, `model_family` when supplied by your
-  config, and Redis `key_prefix` configured by the application.
-- Potentially sensitive fields: `request_id` if it contains customer or trace
-  identifiers; `model_alias` and `model_family` if your naming scheme embeds
-  tenant, deployment, or account data; usage values if request size is
-  sensitive in your environment.
-- Not logged or returned by `snapshot_state()`: Redis URLs, credentials, Redis
-  client objects, and plaintext key prefixes.
-- Never included by token-throttle observability surfaces: prompt text,
-  messages, responses, API keys, or request payload bodies. A custom
-  `usage_counter` or your own callback code may log those separately, so audit
-  application code that you attach to callbacks.
+Debug loggers (`token_throttle.acquire` / `.refund` / `.lock`), lifecycle event
+fields, `snapshot_state()` estimate semantics, callback timeouts, and the full
+PII surface are documented in [docs/observability.md](docs/observability.md).
 
 ## Sync API
 
@@ -701,16 +453,26 @@ Both limiter types can own their close lifecycle through context managers:
 ```python
 # (fragment — see Memory quickstart for standalone context)
 async with RateLimiter(get_config, backend=MemoryBackendBuilder()) as limiter:
-    reservation = await limiter.acquire_capacity({"tokens": 500}, model="gpt-4.1")
-    await limiter.refund_capacity({"tokens": 320}, reservation)
+    reservation = await limiter.acquire_capacity({"requests": 1, "tokens": 500}, model="gpt-4.1")
+    await limiter.refund_capacity({"requests": 1, "tokens": 320}, reservation)
 ```
 
 ```python
 # (fragment — see Sync API example for standalone context)
 with SyncRateLimiter(get_config, backend=SyncMemoryBackendBuilder()) as limiter:
-    reservation = limiter.acquire_capacity({"tokens": 500}, model="gpt-4.1")
-    limiter.refund_capacity({"tokens": 320}, reservation)
+    reservation = limiter.acquire_capacity({"requests": 1, "tokens": 500}, model="gpt-4.1")
+    limiter.refund_capacity({"requests": 1, "tokens": 320}, reservation)
 ```
+
+## Documentation
+
+- [docs/api.md](docs/api.md) — public constants and type aliases
+- [docs/configuration.md](docs/configuration.md) — per-model caps, unlimited configs, custom usage counters, dynamic limits
+- [docs/operations.md](docs/operations.md) — reservation durability, Redis topology, multi-tenant isolation, capacity planning
+- [docs/observability.md](docs/observability.md) — logging, lifecycle events, health snapshots, PII surface
+- [docs/custom-backends.md](docs/custom-backends.md) — implement your own backend
+- [MIGRATION.md](MIGRATION.md) — breaking-change upgrade guides
+- [CHANGELOG.md](CHANGELOG.md) — release history
 
 ## Links
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,104 @@
+# Configuration reference
+
+This reference covers advanced configuration and runtime tuning: per-model
+in-process caps, unlimited configs, the `usage_counter` contract, and runtime
+limit overrides. Start with the [README](../README.md#configuration) for the
+shorter setup path.
+
+See also [docs/api.md](api.md) for public constants and type aliases, and
+[docs/custom-backends.md](custom-backends.md) for implementing your own backend.
+
+## Per-model configuration
+
+A callable config maps each model name to a `PerModelConfig`. The README shows
+the basic shape; this section covers the in-process caps and idle-family
+maintenance that matter for long-lived or dynamic deployments.
+
+`model_family` defaults to the request model name. A typo such as
+`"gpt-4o-mini-prod"` therefore creates a distinct family. Limiters fail closed
+once mandatory in-process caps are reached: by default 10,000 model families,
+100 metrics per family, 10,000 model aliases, and 100,000 in-flight
+reservations. Key-segment length is also capped by default: model families and
+aliases at 256 characters, metrics at 64 characters. Tune these constructor
+arguments lower for tighter deployments and validate model names in your
+application if they come from users or configuration.
+
+Long-lived dynamic deployments should periodically call
+`limiter.clear_unused_model_families(unused_for_seconds)` (or the sync method
+with the same name) from an operator-controlled maintenance path. It evicts idle
+in-process family caches and skips families with in-flight reservations. Redis
+bucket keys expire separately through the Redis bucket TTL.
+
+### Unlimited configs
+
+To disable rate limiting for a model while keeping the same API surface, return
+an unlimited config from your config callable:
+
+```python
+PerModelConfig(
+    quotas=UsageQuotas.unlimited(),
+    model_family="paid-tier",
+)
+```
+
+Unlimited configs still validate direct usage values for `acquire_capacity()`
+but do not require usage keys to match quota names because there are no quotas.
+For `acquire_capacity_for_request()`, a configured `usage_counter` may still run
+for telemetry; any `extra_usage` keys are accepted and then discarded with the
+unlimited reservation. If you toggle a model between limited and unlimited,
+keep `extra_usage` keys compatible with the limited quota metrics.
+
+### Usage counters
+
+`OpenAIUsageCounter` handles text-only OpenAI requests. It counts `input` or
+`messages`, plus prompt-bearing request context such as `instructions`,
+tool/function definitions, and structured output schemas. The plural `inputs`
+field is rejected because it is not an OpenAI request field. Image/audio/file
+inputs are still unsupported; pass usage manually for those.
+
+Token estimates are bounded by `tiktoken`'s model encodings plus local
+best-effort heuristics for chat/message overhead, tools, functions, schemas,
+and output budgets. They have not been reconciled against live OpenAI billing
+dashboards across a request corpus; periodically compare reserved tokens with
+your actual billing and pass usage manually where local counting is not
+representative.
+
+Custom `usage_counter` callables receive the same kwargs you pass to
+`acquire_capacity_for_request()`. They can accept `**request` for the whole
+payload or only the named request fields they use; fixed-signature counters do
+not need to accept unrelated kwargs like `model`. Custom counters are trusted
+application code: nested request objects are passed by reference, so counters
+should avoid mutating them. Return a plain `dict` or another well-behaved
+mapping of metric names to finite numeric values.
+
+## Dynamic rate limits
+
+Adjust bucket limits at runtime without rebuilding the limiter — useful for
+adaptive rate limiting (e.g., reacting to `x-ratelimit-*` response headers):
+
+```python
+# After the limiter has initialized this model with an acquire call:
+await limiter.set_max_capacity(
+    model="gpt-4o",
+    metric="tokens",
+    per_seconds=60,
+    value=5000,
+)
+```
+
+For Redis backends the new limit is written to Redis, so all processes
+sharing the same Redis see the change within ~1 second. This persisted Redis
+value is an explicit runtime override; static quota changes from your config do
+not rewrite it automatically.
+
+If a callable config removes a bucket and later re-adds it, the re-added
+bucket starts from the static quota in the current config. Runtime overrides
+from earlier `set_max_capacity()` calls do not survive a remove-and-readd;
+call `set_max_capacity()` again if you want the override restored.
+
+If you want to change the static configured quota, update the callable config
+and let the limiter rebuild on the next acquire/refund. `set_max_capacity()` is
+an explicit runtime override, not a config edit. Config rotations concurrent
+with `set_max_capacity()` are ordered by whichever backend update completes
+last; a later config rebuild resolves back to the static quota unless you
+reapply the override.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,70 @@
+# Observability reference
+
+token-throttle stays framework-agnostic: it exposes logging, callbacks, and a
+small health snapshot, but does not depend on Prometheus, OpenTelemetry, or any
+metrics SDK. Wire these surfaces to your own collectors.
+
+The [README](../README.md#observability) shows the `snapshot_state()` and
+lifecycle-callback examples. This reference documents the debug loggers,
+lifecycle event fields, callback timeouts, and the full PII surface.
+
+## Logging and debug records
+
+Every `RateLimiter` and `SyncRateLimiter` logs the `token_throttle` package
+version at `INFO` during initialization. Existing callback loggers use the
+`token_throttle` logger by default through `create_logging_callbacks()` and
+`create_sync_logging_callbacks()`. Redis internals also emit structured
+`DEBUG` records under:
+
+- `token_throttle.acquire` for acquire marker reads/writes/deletes.
+- `token_throttle.refund` for refund marker GET/DEL and refund-dedup writes.
+- `token_throttle.lock` for Redis lock acquire, release, and extension events.
+
+Redis debug records include a `token_throttle_event` logging attribute with
+`event_type`, `reservation_id`, `bucket_id`, and operation-specific fields. For
+example, a stdlib handler can read `record.token_throttle_event` and turn it
+into counters or spans.
+
+## Health snapshot
+
+For Redis backends, marker and refund-dedup counts from `snapshot_state()` are
+best-effort local estimates from limiter bookkeeping, not a cross-process Redis
+inventory. The snapshot intentionally omits Redis URLs, credentials, and Redis
+key prefixes.
+
+## Lifecycle events
+
+Lifecycle events include `event_type`, `reservation_id`, optional `request_id`
+from `acquire_capacity_for_request(..., request_id="...")`, `model_family`,
+`model_alias`, `bucket_ids`, `usage`, and `timestamp`. Existing wait, consume,
+refund, and missing-data callbacks keep their original keyword signatures.
+
+## Structured errors
+
+For alerting or retry routing, public token-throttle exception classes expose a
+stable `reason` attribute where callers need structured error handling.
+
+## Callback timeouts
+
+User callbacks are bounded separately by `callback_timeout` on `RateLimiter`
+and `SyncRateLimiter` (default: 30 seconds per callback). When a callback
+exceeds that limit, token-throttle logs a warning, skips the callback result,
+and does not fail the acquire/refund call. Pass `callback_timeout=None` to
+restore unbounded callback execution. Timeout-wrapped sync callbacks run in a
+helper thread with the caller's `contextvars` context copied into that thread.
+
+## PII surface
+
+- User-controlled fields: request `model`, lifecycle `model_alias`, optional
+  `request_id`, custom usage metric names, `model_family` when supplied by your
+  config, and Redis `key_prefix` configured by the application.
+- Potentially sensitive fields: `request_id` if it contains customer or trace
+  identifiers; `model_alias` and `model_family` if your naming scheme embeds
+  tenant, deployment, or account data; usage values if request size is
+  sensitive in your environment.
+- Not logged or returned by `snapshot_state()`: Redis URLs, credentials, Redis
+  client objects, and plaintext key prefixes.
+- Never included by token-throttle observability surfaces: prompt text,
+  messages, responses, API keys, or request payload bodies. A custom
+  `usage_counter` or your own callback code may log those separately, so audit
+  application code that you attach to callbacks.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,177 @@
+# Operations guide
+
+Running token-throttle in production across multiple workers and processes:
+reservation durability, supported Redis topologies, multi-tenant isolation,
+connection/TTL sizing, and capacity planning for high-RPS fleets.
+
+Start with the [README](../README.md) for installation, the mental model, and
+quickstarts. Reach for this guide once you are deploying on Redis and need to
+reason about durability, scaling ceilings, and resource budgets.
+
+## Reservation lifecycle and durability
+
+A `CapacityReservation` is an internal accounting token, not a durable portable
+credential. Refund it on the same limiter lifetime that issued it, after the API
+call finishes. If your config changes before refund, token-throttle refunds only
+the surviving buckets that still correspond to the reservation; buckets removed
+by a callable-config rebuild are skipped to avoid crediting unrelated capacity.
+
+Unlimited reservations are no-ops on refund. They are trusted in-process
+objects, so do not deserialize, pickle, or accept reservations across trust
+boundaries as proof that a caller was rate-limited. For queue-and-retry
+workflows, reserve immediately before dispatching the external request rather
+than storing reservations in a long-lived queue.
+
+v2.0.0 is a clean break from v1.4.x reservation compatibility. Every
+`CapacityReservation` requires a non-empty `limiter_instance_id`; legacy
+v1.4.x reservations without it are rejected. Drain in-flight reservations
+before upgrading and do not run mixed v1.4.x/v2.0.0 fleets. See
+[`MIGRATION.md`](../MIGRATION.md#migrating-from-v14x-to-v200) for the full
+upgrade procedure.
+
+## Redis topology support
+
+token-throttle supports standalone Redis and Sentinel-aware clients connected
+to the current Redis primary. It does not support Redis Cluster or client-side
+sharded Redis.
+The Redis backend uses multi-key Lua scripts for atomic acquire-marker and
+refund updates; in Redis Cluster those keys can span hash slots and fail at
+runtime. `RateLimiter` and `SyncRateLimiter` reject redis-py `RedisCluster`
+clients during construction with a `ValueError` instead of failing later during
+`EVAL`.
+
+Do not add caller-controlled Redis hash tags to key prefixes, model families,
+metrics, reservation ids, or other key segments. Public validators reject `{`
+and `}` in Redis key segments, and Cluster support is intentionally unsupported.
+
+Redis backends require Redis server 6.2 or newer and a Redis user that can run
+`GET`, `EXISTS`, `SET`, `DEL`, `EXPIRE`, `PTTL`, `TIME`, and Lua scripting commands
+used by redis-py locks and token-throttle acquire/refund transactions.
+
+Compatibility testing used `fakeredis` for unit tests plus local standalone
+Redis (7.x for the test matrix, 8.4.0 for the benchmarks below); 6.2 or newer is
+supported and 6.0/6.1 are outside the range. The test matrix did not cover
+Sentinel failover behavior, KeyDB, Dragonfly, client-side sharding, or low
+`maxmemory` / low `maxclients` configurations. KeyDB and Dragonfly may work as
+Redis-compatible servers, but they are untested and not officially supported;
+validate topology and resource limits in your environment.
+
+## Multi-tenant deployments
+
+`key_prefix` provides namespace isolation only. It keeps one tenant's Redis
+keys from colliding with another tenant's keys, but it is not resource
+isolation. Tenants that share a Redis server still share Redis CPU, memory,
+`maxclients`, command scheduling, Lua script execution time, network bandwidth,
+and eviction policy.
+
+Do not rely on `key_prefix` for hostile-tenant fairness. A hostile or runaway
+tenant on shared Redis can starve benign tenants by exhausting connections,
+memory, CPU, or Lua scheduling. For hostile-tenant scenarios, use separate
+Redis instances per tenant, or place Redis behind infrastructure that enforces
+hardware-level CPU, memory, connection, and network quotas per tenant.
+If you are upgrading from a pre-v4 deployment, see [`MIGRATION.md`](../MIGRATION.md)
+for the multi-tenant isolation change.
+
+## Connection pooling and key TTLs
+
+For bounded Redis deployments, prefer `redis.asyncio.BlockingConnectionPool`
+or `redis.BlockingConnectionPool` and size `max_connections` to at least
+`max_concurrent_acquires` plus headroom for Redis lock acquire/release, `TIME`,
+and pipeline commands. A pool below 10 connections triggers a runtime warning
+because it is usually too small for production traffic.
+
+Redis bucket state expires by default after 7 days of inactivity. Configure
+`bucket_ttl_seconds` on Redis builders or Redis OpenAI factories to choose a
+different positive TTL. The TTL is refreshed whenever bucket state is read or
+written; Redis schema-version registry keys are intentionally long-lived and do
+not expire.
+
+Redis refunds also write a cross-process idempotency key:
+`{key_prefix}:rate_limiting:refund_dedup:{reservation_id}`. The TTL defaults to
+7 days and can be changed with `refund_dedup_ttl_seconds` on Redis backend
+builders or Redis OpenAI factories. Memory backends keep only process-local
+refund dedup state and cannot safely refund reservations after a cold restart.
+
+## Performance and capacity planning
+
+Performance testing identified two important ceilings for 10k RPS-class
+deployments:
+
+- A single hot Redis bucket is the throughput ceiling well before 10k RPS,
+  because all callers serialize on the same Redis lock and Lua-scripted state.
+  In a single-machine benchmark — 1,000 workers contending on one bucket,
+  target 10k RPS, local Redis 8.4.0 — throughput collapsed to ~180 ops/s with
+  p99 acquire latency near 4.8s and frequent lock timeouts at the 5s lock-wait
+  boundary.
+- The async memory backend is process-local and also falls short of 10k RPS on
+  a single process: the same benchmark topped out around 4.4k-5.3k ops/s, and
+  raising workers from 100 to 1,000 only inflated tail latency (p99 acquire
+  ~16 ms to ~290 ms) without adding throughput. It is not a horizontal scaling
+  substitute for Redis.
+
+Exact throughput and p99 latency depend on Redis CPU, network RTT, Python
+runtime, concurrency, quota shape, and how concentrated traffic is on one
+model family. Treat 10k RPS as a workload that requires staging benchmarks with
+your real quota mix. These numbers are based on short local runs and sizing
+estimates, not a maintained sustained-load production benchmark suite; use them
+as planning signals, not guarantees. As a starting planning table:
+
+| Sustained acquire/refund rate | Expected p99 driver | Operational guidance |
+| ---: | --- | --- |
+| 100 RPS | Redis RTT plus Python scheduling | Default Redis client pools usually work; still set timeouts and monitor waits. |
+| 1k RPS | Lock contention, Redis CPU, pool wait | Use `BlockingConnectionPool`, provision Redis CPU headroom, and benchmark p99 under peak concurrency. |
+| 10k RPS | Hot buckets, Lua scheduling, key churn | Avoid concentrating all traffic in one model family/window; use dedicated Redis capacity and load-test before production. |
+
+Redis backends create per-reservation keys in addition to bucket
+state. Size Redis from traffic rate and TTLs, not only from the number of model
+families:
+
+- Acquire marker keys, rough count:
+  `acquires_per_second * max_reservation_lifetime_seconds`.
+- Refund dedup keys, rough count:
+  `refunds_per_second * refund_dedup_ttl_seconds`.
+
+The Redis default TTLs are intentionally conservative for correctness and
+compatibility: `bucket_ttl_seconds=604800` and
+`refund_dedup_ttl_seconds=604800` (7 days). With no explicit
+`max_reservation_lifetime_seconds`, Redis derives the reservation lifetime from
+the shorter Redis TTL: just below
+`min(bucket_ttl_seconds, refund_dedup_ttl_seconds) / 2`. At 10k acquires/sec,
+the default derived marker lifetime is about 302,400 seconds, which can imply
+roughly 3.0 billion marker keys. Tune these values for sustained high-RPS
+deployments.
+
+A practical starting point is to choose the smallest reservation lifetime that
+covers normal request latency, retry delay, and shutdown drain time, then choose
+`bucket_ttl_seconds` and `refund_dedup_ttl_seconds` longer than twice that
+lifetime. Redis enforces this invariant:
+`bucket_ttl_seconds > max_reservation_lifetime_seconds * 2` and
+`refund_dedup_ttl_seconds > max_reservation_lifetime_seconds * 2`. The margin
+keeps bucket state, acquire markers, and refund tombstones alive for the full
+window in which a reservation can still be refunded.
+
+Example budgets for a tuned deployment, assuming about 0.5-1.0 KB per marker or
+dedup key after Redis object overhead and leaving operational headroom:
+
+| Traffic | Example knobs | Approx keys | Suggested Redis memory budget |
+| --- | --- | ---: | ---: |
+| 1k acquire/refund RPS | `max_reservation_lifetime_seconds=300`, `refund_dedup_ttl_seconds=900`, `bucket_ttl_seconds=900` | 300k markers + 900k dedup keys | 1-2 GB |
+| 10k acquire/refund RPS | `max_reservation_lifetime_seconds=300`, `refund_dedup_ttl_seconds=900`, `bucket_ttl_seconds=900` | 3M markers + 9M dedup keys | 10-20 GB |
+
+Validate with `INFO memory`, `DBSIZE` or keyspace scans in staging because Redis
+memory per key depends on key-prefix length, allocator behavior, and value size.
+
+Sample Redis monitoring points:
+
+```text
+INFO commandstats   # eval/evalsha, set, get, del latency and call volume
+INFO clients        # connected_clients, blocked_clients, maxclients pressure
+INFO memory         # used_memory, mem_fragmentation_ratio, evicted_keys
+INFO stats          # instantaneous_ops_per_sec, rejected_connections
+LATENCY LATEST      # server-side latency spikes
+SLOWLOG GET 128     # slow Lua scripts or lock commands
+```
+
+Application-side monitoring should track acquire wait duration, timeout count,
+callback errors, `snapshot_state()["in_flight_reservations"]`, Redis pool wait
+time, and p50/p95/p99 latency for acquire and refund calls.

--- a/tests/lint/test_readme_standalone_examples.py
+++ b/tests/lint/test_readme_standalone_examples.py
@@ -194,7 +194,7 @@ _MANUAL_NON_PYTHON_FENCE_KEYS: frozenset[_NonPythonFenceKey] = frozenset()
 _EXPECTED_NON_PYTHON_FENCES = (
     _ExpectedNonPythonFence(
         document_name="README.md",
-        start_line=22,
+        start_line=18,
         language="bash",
         classification=_NON_PYTHON_CLASSIFICATION_SHELL_SYNTAX,
         reason="package installation command; lint syntax-checks but does not execute it",
@@ -207,29 +207,13 @@ _EXPECTED_NON_PYTHON_FENCES = (
     ),
     _ExpectedNonPythonFence(
         document_name="README.md",
-        start_line=91,
+        start_line=89,
         language="bash",
         classification=_NON_PYTHON_CLASSIFICATION_SHELL_SYNTAX,
         reason="package installation command; lint syntax-checks but does not execute it",
         heading="### OpenAI (built-in helpers)",
         non_empty_content_lines=(
-            'pip install "token-throttle[redis,tiktoken]" openai',
-        ),
-    ),
-    _ExpectedNonPythonFence(
-        document_name="README.md",
-        start_line=469,
-        language="text",
-        classification=_NON_PYTHON_CLASSIFICATION_TEXT,
-        reason="Redis monitoring command inventory for operators, not a shell script",
-        heading="#### Performance and capacity planning",
-        non_empty_content_lines=(
-            "INFO commandstats   # eval/evalsha, set, get, del latency and call volume",
-            "INFO clients        # connected_clients, blocked_clients, maxclients pressure",
-            "INFO memory         # used_memory, mem_fragmentation_ratio, evicted_keys",
-            "INFO stats          # instantaneous_ops_per_sec, rejected_connections",
-            "LATENCY LATEST      # server-side latency spikes",
-            "SLOWLOG GET 128     # slow Lua scripts or lock commands",
+            'pip install "token-throttle[redis,tiktoken]>=8.0.6,<8.1.0" openai',
         ),
     ),
     _ExpectedNonPythonFence(
@@ -364,7 +348,7 @@ _EXPECTED_NON_README_STANDALONE_IDENTITIES = (
     ),
     _StandaloneExampleIdentity(
         document_name="DEVELOPMENT.md",
-        start_line=336,
+        start_line=337,
         heading="### Redis connection pool sizing",
         first_non_empty_code_line="import redis.asyncio as aioredis",
     ),
@@ -375,14 +359,14 @@ _EXPLICIT_FRAGMENT_START_LINES_BY_DOCUMENT = {
 _EXPECTED_STDOUT_EXAMPLES = (
     _ExpectedStdoutExample(
         document_name="README.md",
-        start_line=34,
+        start_line=32,
         heading="### Memory quickstart (zero-service)",
         first_non_empty_code_line="import asyncio",
         expected_stdout="reserved 1000 tokens, refunded 575 unused tokens",
     ),
     _ExpectedStdoutExample(
         document_name="README.md",
-        start_line=154,
+        start_line=147,
         heading="### Any provider (manual usage)",
         first_non_empty_code_line="import asyncio",
         expected_stdout=(


### PR DESCRIPTION
## What

Restructures the documentation so the README is a **front door** (pitch →
runnable quickstarts → mental model → pointers) instead of a 719-line dumping
ground that mixed the pitch, a full SRE operations manual, and an API reference.
The reference material is moved **verbatim** (seams smoothed) into three topical
docs, and a Documentation index ties them together.

| | Before | After |
|---|---|---|
| `README.md` | 719 lines / 3617 words | ~470 lines / ~1800 words |
| `docs/operations.md` | — | reservation durability, Redis topology, multi-tenant, capacity planning |
| `docs/configuration.md` | — | per-model caps, unlimited configs, usage counters, dynamic limits |
| `docs/observability.md` | — | logging, lifecycle events, health snapshot, PII surface |

## Why

The README had accreted into a reference manual — production capacity tables,
Redis `INFO`/`SLOWLOG` snippets, and TTL math sat in the adoption path. Splitting
by reader intent keeps the front door enticing while preserving every word of the
hard-won operational detail one click away.

## Correctness fixes found during review

- **TTL example bug:** the capacity-planning table used
  `max_reservation_lifetime_seconds=300, refund_dedup_ttl_seconds=600`, which
  violates the strict `ttl > lifetime * 2` invariant and raises `ValueError`.
  Fixed to `300/900/900`. Verified against the real validator:
  `resolve_max_reservation_lifetime_seconds_from_ttls` accepts the new values and
  rejects the old ones.
- **Redis ACL list** omitted `PTTL`, which the Lua snapshot scripts call
  (`_redis/_backend.py:141,221`). Added.
- **Version inconsistency** between the topology note (Redis 7.x) and the
  benchmark note (8.4.0) reconciled.

## Other changes

- Decoded and removed the internal **"R7"** audit codename from public docs.
- Enriched the perf section with verified benchmark numbers (hot-bucket
  ~180 ops/s @ p99 4.8s; memory backend ~4.4–5.3k ops/s).
- Pinned the OpenAI extras install; relocated the breaking-releases note below
  the install block.
- Repointed `DEVELOPMENT.md`'s sizing reference to `docs/operations.md`.
- Synced `tests/lint/test_readme_standalone_examples.py` to the new structure.

## Verification

- `tests/lint` green (**49 passed**) — this guard *executes* the README/MIGRATION/
  DEVELOPMENT standalone examples, so the edited quickstarts are confirmed
  runnable, and the OpenAI block stays correctly classified as a non-executable
  fragment.
- Doc accuracy independently checked against `token_throttle/` source (caps,
  TTL constants, `RedisCluster` rejection, `OpenAIUsageCounter`, exports, method
  signatures, quickstart API forms — all verified).
- All internal links/anchors resolve; nothing dropped in the split.

## Known unknowns

- The README claims **Redis 6.2+** as a support policy; this is not enforced by a
  runtime version probe in the source — it's a maintainer policy statement.
- The new `docs/*.md` are **not** covered by the `tests/lint` doc-guard (it scans
  README/MIGRATION/DEVELOPMENT/CLAUDE only). Extending the guard to `docs/` is a
  reasonable follow-up.

Merge intentionally left to the maintainer.
